### PR TITLE
Add `solana-logger`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ assert_matches = "1.4.0"
 solana-program-test = "=1.9.1"
 solana-sdk = "=1.9.1"
 solana-validator = "=1.9.1"
+solana-logger = "=1.9.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12,6 +12,7 @@ use {
 
 #[test]
 fn test_validator_transaction() {
+    solana_logger::setup_with_default("solana_program_runtime=debug");
     let program_id = Pubkey::new_unique();
 
     let (test_validator, payer) = TestValidatorGenesis::default()


### PR DESCRIPTION
This PR adds `solana-logger` and provides an example of how to enable logging in the template integration test `integration.rs`.

I think it's sensible to use `setup_with_default` which respects user overriding with `RUST_LOG`.

It wasn't immediately obvious to me how to enable logging within a test and what log filter to use -- I figured it out by digging around the discord -- I figure this might be useful?

