### PR TITLE
Introduce minimal CI for native & BPF builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Solana CLI
+        run: |
+          sh -c "$(curl -sSfL https://release.solana.com/v1.16.1/install)"
+          echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Native build
+        run: cargo build
+
+      - name: Native tests
+        run: cargo test
+
+      - name: Build BPF
+        run: cargo build-bpf
+
+      - name: Test BPF
+        run: cargo test-bpf


### PR DESCRIPTION
This PR adds a minimal CI workflow intended for the template environment.

Included:
- Native Rust build + tests (`cargo build`, `cargo test`)
- Solana BPF build + tests (`cargo build-bpf`, `cargo test-bpf`)
- Automatic Solana CLI installation
- Cached Cargo registry to reduce build times

The workflow is intentionally simple and focused only on validating that the template compiles and works as expected.

No functional changes to the program code.
